### PR TITLE
Fix table wrapping & add scroll feature

### DIFF
--- a/2018/shinkan/index.html
+++ b/2018/shinkan/index.html
@@ -149,7 +149,7 @@
             </tr>
             <tr>
               <th>12</th> <td>木</td>
-              <td class="description"><span class="label label-sci">理学</span>郡論序説</td> <td></td> <td></td> <td></td>
+              <td class="description"><span class="label label-sci">理学</span>群論序説</td> <td></td> <td></td> <td></td>
             </tr>
             <tr>
               <th>13</th> <td>金</td>

--- a/2018/shinkan/index.html
+++ b/2018/shinkan/index.html
@@ -49,7 +49,7 @@
         <ul class="side">
           <li><a href="../../" class="links_a">HOME</a></li>
           <li><a href="../../about" class="links_a">LYNCSについて</a></li>
-          <li><a href="../../sat" class="links_a">衛星ミッション本部</a></li>
+          <li><a href="../../sat" class="links_a">工学研究本部</a></li>
           <li><a href="../../astro" class="links_a">天文研究本部</a></li>
           <li><a href="../../science" class="links_a">理学研究本部</a></li>
           <li><a href="../advance" class="links_a">先進技術研究本部</a></li>
@@ -110,6 +110,7 @@
         今年行う新歓企画の一覧です。
         各本部がそれぞれ独自に企画した活動を行いますので、興味のある企画にぜひご参加ください！
         </p>
+        <div  class="table-wrapper"> <!-- 溢れた部分をスクロールさせる -->
         <table rules="all" class="border-table">
           <thead>
             <tr> <th>4月</th> <th>曜日</th> <th>内容</th> <th>時間</th> <th>場所</th> <th>費用</th> </tr>
@@ -195,6 +196,7 @@
             -->
             </tbody>
         </table>
+        </div> 
       </div>
 
       <div class="content_element">

--- a/css/content.css
+++ b/css/content.css
@@ -253,13 +253,28 @@ a:active { color: #FFFFFF; }
   background-color: #37b624;
 }
 
+.table-wrapper {
+  overflow-x: scroll;
+  background: linear-gradient(to left, transparent, rgba(0, 0, 0, 0.2)) 0 0/20px 100%, linear-gradient(to right, transparent, rgba(0, 0, 0, 0.2)) right/20px 100%;
+  background-repeat: no-repeat;
+  background-attachment: scroll;
+  margin-bottom: 10px;
+}
+
 table.border-table {
   width: 100%;
   border: solid 2px #666;
-  background: #f5f5f5;
-  margin-bottom: 10px;
+  background: linear-gradient(to left, transparent, white 15px) 0 0/50px 100%, linear-gradient(to right, transparent, white 15px) right/50px 100%;
+  background-repeat: no-repeat;
+  background-attachment: local;
   text-align: center;
   vertical-align: middle;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+table.border-table thead , table.border-table tbody {
+  background: rgba(0, 0, 0, 0.1);
 }
 
 table.border-table tr {
@@ -270,12 +285,12 @@ table.border-table td {
   border: solid 1px #aaa;
   color: #222;
   font-size: 90%;
-  white-space: nowrap;
-  overflow: hidden;
 }
 
 table.border-table td.description {
   text-align: left;
+  min-width: 250px;
+  white-space: normal;
 }
 
 table.border-table td.satday {


### PR DESCRIPTION
![scroll](https://user-images.githubusercontent.com/16277200/38046017-7017e04a-32f9-11e8-8bd5-e9842275425e.PNG)

新歓ページの表が行折り返しされておらずモバイルでの見栄えが悪いため、折返しを解除した上で横スクロールを実装しました。
ただし、「内容」の列がかなり横に長くPC解像度でもスクロールが発生してしまうので、「内容」に限っては折返すようにしました。
https://github.com/LYNCS-Keio/lyncs-official-web/blob/6f5673f3de618c9f21aa8bb4a34728781fde926f/css/content.css#L290-L294
